### PR TITLE
Adding possibility to do incremental send + using SystemModstamp

### DIFF
--- a/pysalesforce/useful.py
+++ b/pysalesforce/useful.py
@@ -31,6 +31,18 @@ def get_column_names(data):
     return column_list
 
 
+def custom_send(datamart, data, schema, table, column_names, incremental=False):
+    if incremental:
+        data_to_send = {
+            "columns_name": column_names,
+            "data": data,
+            "table_name": f"{schema}.{table}"
+        }
+        datamart.send(data_to_send)
+    else:
+        datamart.send_with_temp_table(data, column_names, 'id', schema, table)
+
+
 def send_temp_data(datamart, data, schema_prefix, table, column_names):
     data_to_send = {
         "columns_name": column_names,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysalesforce",
-    version="0.0.13",
+    version="0.0.14",
     author="Dacker",
     author_email="hello@dacker.co",
     description="A Salesforce connector",


### PR DESCRIPTION
- `incremental` can be given as an input parameter at time of creating Salesforce class, in order to do a send + append instead of send_with_temp_table + cleaning
- In this case, I switched the incremental field to use to retrieve data to `SystemModstamp`, as this one includes includes modifications made by SF procedures etc, whereas `LastmodifiedDate` only included changes made by a User on the platform