### PR TITLE
Updating send method for bulk job treatments

### DIFF
--- a/pysalesforce/Salesforce.py
+++ b/pysalesforce/Salesforce.py
@@ -158,7 +158,7 @@ class Salesforce:
             imported_at=_object.get('imported_at')
         )
         columns = get_column_names(data)
-        dbstream.send_with_temp_table(data, columns, 'id', schema, table)
+        custom_send(dbstream, data, schema, table, columns, incremental=self.incremental)
 
         while locator != "null":
             raw_data, locator = self.get_data_completed_job(job_id, locator)
@@ -167,7 +167,7 @@ class Salesforce:
                 remove_columns=_object.get('remove_columns'),
                 imported_at=_object.get('imported_at')
             )
-            dbstream.send_with_temp_table(data, columns, 'id', schema, table)
+            custom_send(dbstream, data, schema, table, columns, incremental=self.incremental)
         self.dbstream.execute_query("update %s._jobs set fetched_at='%s' where id='%s'" % (
             schema, datetime.datetime.now(), job_id)
                                     )

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pysalesforce",
-    version="0.0.14",
+    version="0.0.15",
     author="Dacker",
     author_email="hello@dacker.co",
     description="A Salesforce connector",


### PR DESCRIPTION
This PR to use the `custom_send` method to send data instead of `send_with_temp_table`
`custom_send` actually uses either:
- a standard `send` in append mode if `self.incremental=True`
- a `send_with_temp_table` like before if `self.incremental=False`
This to not break the behavior prior to this change.